### PR TITLE
tailwind peer style 적용안됨 문제해결

### DIFF
--- a/app/fun/components/BRgame.tsx
+++ b/app/fun/components/BRgame.tsx
@@ -32,17 +32,19 @@ const ComputerTurn = ({ number, setNumber }: BRgameProps) => {
       setNumber(numbers[numbers.length - 1]);
     }
 
-    const interval = setInterval(setComputerNumbers, 3000);
+    const interval = setInterval(setComputerNumbers, 2000); //interval = setInterval의 ID
     return () => clearInterval(interval);
   }, []);
 
   const numbers = computeNumber(number).join(", ");
   const words = useTypingWords(`My turn! : ${numbers}`, 100);
 
+  //TODO: 스킵 기능 구현, 버튼을 누르면 바로 유저턴으로 넘어가게
+
   return (
     <div>
-      <p className="bg-slate-100 bg-opacity-100 dark:bg-opacity-20 py-2 px-4 animate-typing">
-        {words || "M"}
+      <p className="bg-slate-100 bg-opacity-100 dark:bg-opacity-20 py-2 px-4 animate-typing cursor-pointer h-10">
+        {words || " "}
       </p>
     </div>
   );
@@ -52,8 +54,8 @@ const UserTurn = ({ number, setNumber }: BRgameProps) => {
   const numbers = [];
   const peerClassName = [
     "",
-    `${generatePeerClassName(number + 3)}`,
-    `${generatePeerClassName(number + 3)} ${generatePeerClassName(number + 2)}`,
+    `peer-hover/btn0:bg-slate-300`,
+    `peer-hover/btn0:bg-slate-300 peer-hover/btn1:bg-slate-300`,
   ];
 
   if (number == 30) {
@@ -73,7 +75,7 @@ const UserTurn = ({ number, setNumber }: BRgameProps) => {
       <div className="mt-2 flex flex-row-reverse justify-end">
         {numbers.map((num, idx) => (
           <button
-            className={`peer/btn${num} ${peerClassName[idx]} bg-slate-700 bg-opacity-10 dark:bg-opacity-70 px-2 py-1 rounded-md mr-2 hover:bg-slate-300 transition-all`}
+            className={`peer/btn${idx} ${peerClassName[idx]} bg-slate-700 bg-opacity-10 dark:bg-opacity-70 px-2 py-1 rounded-md mr-2 hover:bg-slate-300 transition-all`}
             key={num}
             onClick={() => setNumber(num)}
           >
@@ -87,7 +89,7 @@ const UserTurn = ({ number, setNumber }: BRgameProps) => {
 
 export default function BRgame() {
   const [isUserTurn, setIsUserTurn] = useState(false);
-  const [number, setNumber] = useState(-1);
+  const [number, setNumber] = useState(-1); // number = 0 ~ 31
 
   useEffect(() => {
     if (number <= 0) {
@@ -105,7 +107,10 @@ export default function BRgame() {
     <div>
       <p> Let&apos;s play the Baskin Robbins 31 game!</p>
       <p>The rules are simple: You can call out up to three numbers.</p>
-      <p>The person who spells out the number 31 is the loser of this game.</p>
+      <p>
+        The person who spells out the number 31 is the loser of this game. Good
+        Luck!
+      </p>
 
       <br />
 

--- a/app/fun/hooks/useTypingWords.ts
+++ b/app/fun/hooks/useTypingWords.ts
@@ -22,6 +22,7 @@ const useTypingWords = (completWords: string, delay: number) => {
       clearInterval(typingWords);
     };
   });
+
   return words;
 };
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/fun/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
tailwind에서 peer 스타일이 잘 적용이 되지 않았던 문제를 해결했다.

다시 코드를 보니 불필요하게 button마다 이름을 하나씩 지정해주고 있어서, 0, 1, 2번을 지정하고 재활용하기로 했다.
함수 generatePeerClassName을 템플릿 리터럴 안에 넣어서 dynamic하게 스타일을 지정해줬는데, 그 지점이 문제인 것 같다.

tailwind 공식 문서에서도 다음과 같이 강조하고 있다. (참고: [[링크]](https://tailwindcss.com/docs/content-configuration#dynamic-class-names))
The most important implication of how Tailwind extracts class names is that it will only find classes that exist as **complete unbroken strings** in your source files.

generatePeerClassName 함수를 보면 완전히 그 규정을 어기고 있었다. 

```
function generatePeerClassName(number: number) {
  return `peer-hover/btn${number}:bg-slate-300`;
```
따라서 number자리에 0, 1, 2을 넣고, 아예 hard code로 배열을 만드니 해결됐다.

다만 의문인 것은 여전히 렌더링할떄 peer/btn${idx} 과 같은 uncomplete한 style을 쓰고 있다. 하지만 정상적으로 동작한다.
내 추측은 peer-hover/btn0:bg-slate-300 를 CSS로 파싱하는 과정에서, peer/btn0에 대한 정보를 정상적으로 생성했기 때문에 그런 것 같다.

생성된 CSS를 보면 다음과 같다.
.peer\/btn0:hover~.peer-hover\/btn0\:bg-slate-300 {
...
}
즉, peer-hover/btn0:bg-slate-300 만 가지고 peer/btn0이 hover 되는 경우 특정 스타일이 정상적으로 나타나도록 동작한다.
하지만 tailwind가 알아볼 수 있는 더 깔끔한 코드를 위해서는. peer/btn${idx}  대신에 array로 미리 peer/btn{0, 1, 2}를 만들어놓고 index로 access 해보는게 좋겠다.

close #2 